### PR TITLE
Add IoOptimized to ScalingConfigurationRequest. 

### DIFF
--- a/aliyun-python-sdk-ess/aliyunsdkess/request/v20140828/CreateScalingConfigurationRequest.py
+++ b/aliyun-python-sdk-ess/aliyunsdkess/request/v20140828/CreateScalingConfigurationRequest.py
@@ -29,6 +29,12 @@ class CreateScalingConfigurationRequest(RpcRequest):
 	def set_OwnerId(self,OwnerId):
 		self.add_query_param('OwnerId',OwnerId)
 
+	def get_IoOptimized(self):
+		return self.get_query_params().get('IoOptimized')
+
+	def set_IoOptimized(self,IoOptimized):
+		self.add_query_param('IoOptimized',IoOptimized)
+
 	def get_ResourceOwnerAccount(self):
 		return self.get_query_params().get('ResourceOwnerAccount')
 


### PR DESCRIPTION
Without this, creating a scaling group fails with the following error:
```
{
    "Message": "The specified value of parameter \"ioOptimized\" is not valid.",
    "Code": "InvalidParameter"
}
```

tested via cli:
```
aliyuncli ess CreateScalingConfiguration --ScalingGroupId HIDDEN --ImageId HIDDEN --InstanceType HIDDEN --SecurityGroupId HIDDEN --SecurityGroupId HIDDEN --IoOptimized optimized
```