### PR TITLE
Patch --DataDisks to work

### DIFF
--- a/aliyun-python-sdk-ecs/aliyunsdkecs/request/v20140526/CreateInstanceRequest.py
+++ b/aliyun-python-sdk-ecs/aliyunsdkecs/request/v20140526/CreateInstanceRequest.py
@@ -18,6 +18,7 @@
 # under the License.
 
 from aliyunsdkcore.request import RpcRequest
+import ast
 class CreateInstanceRequest(RpcRequest):
 
 	def __init__(self):
@@ -309,6 +310,7 @@ class CreateInstanceRequest(RpcRequest):
 		return self.get_query_params().get('DataDisks')
 
 	def set_DataDisks(self,DataDisks):
+		DataDisks = ast.literal_eval(DataDisks)
 		for i in range(len(DataDisks)):	
 			if DataDisks[i].get('Size') is not None:
 				self.add_query_param('DataDisk.' + bytes(i + 1) + '.Size' , DataDisks[i].get('Size'))


### PR DESCRIPTION
The current code throws this error:
```
'str' object has no attribute 'get'
```

This patch enables users to use the `--DataDisks` parameter as follows:
```
--DataDisks "[{'DeleteWithInstance':'true','Category':'cloud_efficiency','Size':'20'}]"
```