### PR TITLE
Import DecsribeRegionsRequest into aliyunsdkecs.request

### DIFF
--- a/aliyun-python-sdk-ecs/aliyunsdkecs/request/__init__.py
+++ b/aliyun-python-sdk-ecs/aliyunsdkecs/request/__init__.py
@@ -1,0 +1,1 @@
+from v20140526 import DescribeRegionsRequest


### PR DESCRIPTION
so it can be imported by other modules without knowing the
versioning scheme. This will provide a more stable interface for
clients. Related to
https://github.com/ansible/ansible/pull/55765

