### PR TITLE
Fix time format

### DIFF
--- a/aliyun-python-sdk-core/aliyunsdkcore/utils/parameter_helper.py
+++ b/aliyun-python-sdk-core/aliyunsdkcore/utils/parameter_helper.py
@@ -29,7 +29,7 @@ from aliyunsdkcore.compat import ensure_bytes, ensure_string
 
 TIME_ZONE = "GMT"
 FORMAT_ISO_8601 = "%Y-%m-%dT%H:%M:%SZ"
-FORMAT_RFC_2616 = "%a, %d %b %Y %X GMT"
+FORMAT_RFC_2616 = "%a, %d %b %Y %H:%M:%S GMT"
 
 
 def get_uuid():


### PR DESCRIPTION
Using %X (locale) to get the time can result in a format that is not supported by the Alicloud API.

For example, having a locale of `t_fmt="%r"` for `LC_TIME` results in the time format of `Wed, 12 Feb 2020 01:42:42 AM GMT` which does not work with the API between 12.00-01.00 GMT, throwing the below error:

```
aliyunsdkcore.acs_exception.exceptions.ServerException: HTTP Status: 400 Error:InvalidTimeStamp.Expired Specified time stamp or date value is expired. RequestID: 
```

I believe the API wants time in the format of `Wed, 12 Feb 2020 01:42:42 GMT` (no AM/PM), which is what this MR does.