### PR TITLE
Replace pycryptodome with cryptography

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - pip install coverage
   - pip install pycodestyle
   - pip install mock
-  - pip install jmespath
+  - pip install jmespath cryptography
 
 script:
   - make lint

--- a/aliyun-python-sdk-core/setup.py
+++ b/aliyun-python-sdk-core/setup.py
@@ -18,9 +18,7 @@
  under the License.
 '''
 
-import logging
 import os
-import platform
 
 from setuptools import setup, find_packages
 
@@ -45,15 +43,9 @@ with open("README.rst") as fp:
     LONG_DESCRIPTION = fp.read()
 
 requires = [
-    "jmespath>=0.9.3,<1.0.0"
+    "jmespath>=0.9.3,<1.0.0",
+    "cryptography>=2.9.2"
 ]
-
-if platform.system() != "Windows":
-    requires.append("pycryptodome>=3.4.7")
-else:
-    logging.warning(
-        "auth type [publicKeyId] is disabled because "
-        "'pycrypto' not support windows, we will resolve this soon")
 
 setup_args = {
     'version': VERSION,

--- a/aliyun-python-sdk-core/setup3.py
+++ b/aliyun-python-sdk-core/setup3.py
@@ -20,8 +20,6 @@
 
 from setuptools import setup, find_packages
 import os
-import platform
-import logging
 
 """
 Setup module for core.
@@ -47,16 +45,9 @@ with open("README.rst") as fp:
 
 
 requires = [
-    "jmespath>=0.9.3,<1.0.0"
+    "jmespath>=0.9.3,<1.0.0",
+    "cryptography>=2.9.2"
 ]
-
-if platform.system() != "Windows":
-    requires.append("pycryptodome>=3.4.7")
-else:
-    logging.warning(
-        "auth type [publicKeyId] is disabled because "
-        "'pycrypto' not support windows, we will resolve this soon")
-
 
 setup_args = {
     'version': VERSION,

--- a/aliyun-python-sdk-core/tests/auth/algorithm/test_sha_hmac256.py
+++ b/aliyun-python-sdk-core/tests/auth/algorithm/test_sha_hmac256.py
@@ -1,11 +1,8 @@
 # coding=utf-8
 
 from tests import unittest
-import platform
 
-from mock import MagicMock, patch
 from aliyunsdkcore.auth.algorithm import sha_hmac256 as hmac256
-from aliyunsdkcore.acs_exception.exceptions import ClientException
 
 
 class TestShaHmac256(unittest.TestCase):
@@ -14,37 +11,7 @@ class TestShaHmac256(unittest.TestCase):
         self.assertEqual(hmac256.get_signer_type(), "PRIVATEKEY")
         self.assertEqual(hmac256.get_signer_version(), "1.0")
 
-    @unittest.skip
     def test_sha_hmac256(self):
-        if platform.system() != "Windows":
-            secret = '''MIICeQIBADANBgkqhkiG9w0BAQEFAASCAmMwggJfAgEAAoGBAOJC+2WXtkXZ+6sa
-3+qJp4mDOsiZb3BghHT9nVbjTeaw4hsZWHYxQ6l6XDmTg4twPB59LOGAlAjYrT31
-3pdwEawnmdf6zyF93Zvxxpy7lO2HoxYKSjbtXO4I0pcq3WTnw2xlbhqHvrcuWwt+
-FqH9akzcnwHjc03siZBzt/dwDL3vAgMBAAECgYEAzwgZPqFuUEYgaTVDFDl2ynYA
-kNMMzBgUu3Pgx0Nf4amSitdLQYLcdbQXtTtMT4eYCxHgwkpDqkCRbLOQRKNwFo0I
-oaCuhjZlxWcKil4z4Zb/zB7gkeuXPOVUjFSS3FogsRWMtnNAMgR/yJRlbcg/Puqk
-Magt/yDk+7cJCe6H96ECQQDxMT4S+tVP9nOw//QT39Dk+kWe/YVEhnWnCMZmGlEq
-1gnN6qpUi68ts6b3BVgrDPrPN6wm/Z9vpcKNeWpIvxXRAkEA8CcT2UEUwDGRKAUu
-WVPJqdAJjpjc072eRF5g792NyO+TAF6thBlDKNslRvFQDB6ymLsjfy8JYCnGbbSb
-WqbHvwJBAIs7KeI6+jiWxGJA3t06LpSABQCqyOut0u0Bm8YFGyXnOPGtrXXwzMdN
-Fe0zIJp5e69zK+W2Mvt4bL7OgBROeoECQQDsE+4uLw0gFln0tosmovhmp60NcfX7
-bLbtzL2MbwbXlbOztF7ssgzUWAHgKI6hK3g0LhsqBuo3jzmSVO43giZvAkEA08Nm
-2TI9EvX6DfCVfPOiKZM+Pijh0xLN4Dn8qUgt3Tcew/vfj4WA2ZV6qiJqL01vMsHc
-vftlY0Hs1vNXcaBgEA=='''
-            result = hmac256.get_sign_string("source", secret)
-            self.assertEqual(
-                result, "UNyJPD27jjSNl70b02E/DUtgtNESdtAuxbNBZTlksk1t/GYjiQNRlF"
-                "Iubp/EGKcWsqs7p5SFKnNiSRqWG3A51VmJFBXXtyW1nwLC9xY/MbUj6JVWNYCu"
-                "LkPWM942O+GAk7N+G8ZQZt7ib2MhruDAUmv1lLN26lDaCPBX2MJQJCo=")
-            result = hmac256.get_sign_string("中文unicode", secret)
-            self.assertEqual(
-                result, "UMmvLGAtZAiQIHhtNCkIQyvfAlbmGKVCM4Kz+HZQBgcXzc6qSjVNWQ"
-                "V5GFAh6w6Kzmhh7jpBf24Xybg88APEBfpCVDzWHrXBi38bV8xOik3dmiIcp4XI"
-                "wndwixLwv8fJ4O5WSliN6hJTflWSeUxP+H2AjWNb2XUzYmSzOt81t4Y=")
-
-    @patch("platform.system")
-    def test_sha_hmac256_windows(self, mock_system):
-        mock_system.return_value = "Windows"
         secret = '''MIICeQIBADANBgkqhkiG9w0BAQEFAASCAmMwggJfAgEAAoGBAOJC+2WXtkXZ+6sa
 3+qJp4mDOsiZb3BghHT9nVbjTeaw4hsZWHYxQ6l6XDmTg4twPB59LOGAlAjYrT31
 3pdwEawnmdf6zyF93Zvxxpy7lO2HoxYKSjbtXO4I0pcq3WTnw2xlbhqHvrcuWwt+
@@ -59,10 +26,13 @@ Fe0zIJp5e69zK+W2Mvt4bL7OgBROeoECQQDsE+4uLw0gFln0tosmovhmp60NcfX7
 bLbtzL2MbwbXlbOztF7ssgzUWAHgKI6hK3g0LhsqBuo3jzmSVO43giZvAkEA08Nm
 2TI9EvX6DfCVfPOiKZM+Pijh0xLN4Dn8qUgt3Tcew/vfj4WA2ZV6qiJqL01vMsHc
 vftlY0Hs1vNXcaBgEA=='''
-        with self.assertRaises(ClientException) as ex:
-            hmac256.get_sign_string("source", secret)
-        self.assertEqual(ex.exception.error_code, 'SDK.NotSupport')
+        result = hmac256.get_sign_string("source", secret)
         self.assertEqual(
-            ex.exception.message, "auth type [publicKeyId] is disabled in "
-            "Windows because 'pycrypto' is not supported, we will resolve this soon")
-        mock_system.assert_called_once_with()
+            result, "UNyJPD27jjSNl70b02E/DUtgtNESdtAuxbNBZTlksk1t/GYjiQNRlF"
+            "Iubp/EGKcWsqs7p5SFKnNiSRqWG3A51VmJFBXXtyW1nwLC9xY/MbUj6JVWNYCu"
+            "LkPWM942O+GAk7N+G8ZQZt7ib2MhruDAUmv1lLN26lDaCPBX2MJQJCo=")
+        result = hmac256.get_sign_string("中文unicode", secret)
+        self.assertEqual(
+            result, "UMmvLGAtZAiQIHhtNCkIQyvfAlbmGKVCM4Kz+HZQBgcXzc6qSjVNWQ"
+            "V5GFAh6w6Kzmhh7jpBf24Xybg88APEBfpCVDzWHrXBi38bV8xOik3dmiIcp4XI"
+            "wndwixLwv8fJ4O5WSliN6hJTflWSeUxP+H2AjWNb2XUzYmSzOt81t4Y=")


### PR DESCRIPTION
This adds support for publicKeyId auth type on Windows.

cryptography: https://github.com/pyca/cryptography

- [x] unit tests and/or feature tests
