### PR TITLE
Allow using jmespath 1.x

### DIFF
--- a/aliyun-python-sdk-core/setup.py
+++ b/aliyun-python-sdk-core/setup.py
@@ -19,9 +19,8 @@
 '''
 
 import os
-import sys
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 """
 Setup module for core.
@@ -44,8 +43,8 @@ with open("README.rst") as fp:
     LONG_DESCRIPTION = fp.read()
 
 requires = [
-    "jmespath>=0.9.3,<1.0.0",
-    "cryptography>=3.0.0"
+    "jmespath>=0.9.3,<2.0.0",
+    "cryptography>=3.0.0",
 ]
 
 setup_args = {


### PR DESCRIPTION
Relax the `aliyun-python-sdk-core` requirements to support jmespath 1.x and Python 3.11.

With the changes in the `random` package in Python 3.11, the `random.sample` function now requires a sequence as its first argument. This issue has been addressed in jmespath with this PR: https://github.com/jmespath/jmespath.py/pull/217.

The usage of `jmespath` in this SDK is straightforward and does not necessitate a 0.x version. Therefore, we can relax the constraint to allow 1.x versions as well to ensure broader SDK support for new Python versions.